### PR TITLE
:sparkles: Implement custom code checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,7 @@ Features
 * Define supported upgrade paths in settings using Semantic Versioning.
 * Integrates with Django's system check framework, preventing migrations from running
   on invalid upgrade paths.
-* Planned: run management commands as part of a check.
-* Planned: hook up your own checks as simple python functions.
+* Run management commands as part of a check, or even entirely custom code.
 * Battle-tested and doesn't get in the way during development.
 
 Installation and usage

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,8 +32,7 @@ Features
 * Define supported upgrade paths in settings using Semantic Versioning.
 * Integrates with Django's system check framework, preventing migrations from running
   on invalid upgrade paths.
-* Planned: run management commands as part of a check.
-* Planned: hook up your own checks as simple python functions.
+* Run management commands as part of a check, or even entirely custom code.
 * Battle-tested and doesn't get in the way during development.
 
 .. toctree::

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -28,7 +28,7 @@ complete without errors:
     UPGRADE_CHECK_PATHS = {
         "2.0.0": UpgradeCheck(
             VersionRange(minimum="1.0.2"),
-            commands=[
+            code_checks=[
                 CommandCheck("my_management_command", options={"interactive": False}),
             ],
         ),
@@ -40,3 +40,14 @@ Available checks
 
 .. automodule:: upgrade_check
     :members:
+
+Code checks
+===========
+
+Management command checks are built-in specializations of the generic
+:class:`upgrade_check.constraints.CodeCheck` protocol. You can define your own custom
+code checks and hook them up if desired.
+
+.. autoclass:: upgrade_check.constraints.CodeCheck
+    :members:
+    :undoc-members:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 from semantic_version import Version
 
@@ -206,7 +208,7 @@ def test_management_command_fails_check():
     upgrade_config = {
         "1.1.0": UpgradeCheck(
             valid_range=VersionRange(minimum="1.0.0"),
-            commands=[
+            code_checks=[
                 CommandCheck("fail_upgrade_check", options={"fail": True}),
             ],
         )
@@ -223,7 +225,7 @@ def test_management_command_passes_check():
     upgrade_config = {
         "1.1.0": UpgradeCheck(
             valid_range=VersionRange(minimum="1.0.0"),
-            commands=[CommandCheck("fail_upgrade_check")],
+            code_checks=[CommandCheck("fail_upgrade_check")],
         )
     }
 
@@ -232,3 +234,41 @@ def test_management_command_passes_check():
     )
 
     assert result is True
+
+
+@dataclass
+class Check:
+    outcome: bool
+
+    def execute(self) -> bool:
+        return self.outcome
+
+
+def test_custom_code_check_pass():
+    upgrade_config = {
+        "1.1.0": UpgradeCheck(
+            valid_range=VersionRange(minimum="1.0.0"),
+            code_checks=[Check(outcome=True)],
+        )
+    }
+
+    result = check_upgrade_possible(
+        upgrade_config, from_version="1.0.0", to_version="1.1.0"
+    )
+
+    assert result is True
+
+
+def test_custom_code_check_fail():
+    upgrade_config = {
+        "1.1.0": UpgradeCheck(
+            valid_range=VersionRange(minimum="1.0.0"),
+            code_checks=[Check(outcome=False)],
+        )
+    }
+
+    result = check_upgrade_possible(
+        upgrade_config, from_version="1.0.0", to_version="1.1.0"
+    )
+
+    assert result is False

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -23,6 +23,7 @@ def test_record_new_version(settings):
     assert version.git_sha == "abcd1234"
     assert version.timestamp is not None
     assert version.machine_name != ""
+    assert "1.2.3@" in str(version)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Implemented as a generic case/flavour of management commands by leveraging protocols/duck typing. Management command checks are treated as a built-in batteries-included version of generic code checks.

This setup gives maximum control over the order of check execution, which the Open Forms version was lacking.