### PR TITLE
:technologist: [#3] Support for higher versions and fix tests

### DIFF
--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -133,6 +133,8 @@ UPGRADE_CONFIG = {
     [
         ("1.0.0", "1.4.0", False),
         ("1.2.1", "1.4.0", False),
+        ("1.2.1", "1.5.0", False),
+        ("1.2.2", "1.5.0", True),
         ("1.2.2", "1.4.0", True),
         ("1.2.3", "1.4.0", True),
         ("1.2.3", "1.4.1", True),
@@ -140,11 +142,15 @@ UPGRADE_CONFIG = {
         ("1.2.9", "1.4.2", True),
         ("1.2.10", "1.4.2", False),
         ("1.3.3", "1.4.0", False),
+        ("1.3.3", "1.5.0", False),
         ("1.3.4", "1.4.0", True),
+        ("1.3.4", "1.5.0", True),
         ("1.3.999", "1.4.999", True),
         ("1.4.0", "1.4.0", True),
         ("1.3.5", "1.4.9", False),
+        ("1.3.5", "1.5.0", True),
         ("1.4.4", "1.4.9", True),
+        ("1.4.4", "1.5.0", True),
     ],
 )
 def test_upgrade_possible(from_version: str, to_version: str, expected_result: bool):
@@ -152,7 +158,7 @@ def test_upgrade_possible(from_version: str, to_version: str, expected_result: b
         UPGRADE_CONFIG,
         from_version=from_version,
         to_version=to_version,
-        raise_if_no_match=True,
+        raise_if_no_match=False,
     )
 
     assert result == expected_result

--- a/tests/test_upgrade_checks.py
+++ b/tests/test_upgrade_checks.py
@@ -56,16 +56,16 @@ def test_upgrade_check_no_prior_history_upgrade_ok(settings):
     assert not result.error
 
 
-def test_upgrade_check_undefined_target_version_with_lax_checks(settings):
+def test_upgrade_check_undefined_target_version_ok(settings):
     settings.RELEASE = "4.0.0"
     settings.GIT_SHA = "abcd1234"
     Version.objects.create(version="1.3.4", git_sha="dummy")
 
     result = run_upgrade_check()
 
-    assert result.ok
+    assert not result.ok
     assert not result.warning
-    assert not result.error
+    assert result.error
 
 
 def test_upgrade_check_undefined_target_version_with_strict_checks(settings):

--- a/upgrade_check/constraints.py
+++ b/upgrade_check/constraints.py
@@ -25,6 +25,9 @@ __all__ = [
     "check_upgrade_possible",
 ]
 
+OP_GREATER_OR_EQUAL = ">="
+OP_COMPATIBLE = "~="
+
 
 @dataclass(slots=True, unsafe_hash=True)
 class VersionRange:
@@ -193,16 +196,17 @@ def check_upgrade_possible(
         raise InvalidVersionError(str(exc)) from exc
 
     # find the most appropriate constraint - check for exact matches first
+    operator = OP_GREATER_OR_EQUAL if not raise_if_no_match else OP_COMPATIBLE
     target_version: str
     if to_version in upgrade_paths:
         target_version = to_version
-        compare_spec = SimpleSpec(f"~={target_version}")
+        compare_spec = SimpleSpec(f"{operator}{target_version}")
     else:
         for target_version in upgrade_paths:
             # 2. Check the ~=X.Y.x version range, which allows the major.minor range.
             # E.g. 2.0.1 matches ~= 2.0.0, but 2.1.0 does not. Similarly, 1.5 matches
             # ~= 1.4 (!).
-            compare_spec = SimpleSpec(f"~={target_version}")
+            compare_spec = SimpleSpec(f"{operator}{target_version}")
             if _to_version in compare_spec:
                 break
         else:


### PR DESCRIPTION
Fixes #3 

https://peps.python.org/pep-0440/#compatible-release

The change consist to update the operator, the `~=` operator, checks whether the versions are compatible at the `patch` level (or it checks the least significant bit, so if you specify the `patch` it will only compare the `patch`, if you specify the `minor`, it will only check the `minor`), but the request is to check all higher versions from a specific version

Ex:
```
Version('4.2.1') in SimpleSpec("~=4.2.2") # False
Version('4.2.2') in SimpleSpec("~=4.2.2") # True
.
.
.
Version('4.2.9') in SimpleSpec("~=4.2.2") # True
Version('4.3.0') in SimpleSpec("~=4.2.2") # False

# But this
Version('4.3.0') in SimpleSpec("~=4.2") # True
Version('4.3.1') in SimpleSpec("~=4.2") # True
```
