### PR TITLE
:bug: Fix migrating a partial plan that stops before our initial

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ tests = [
     "ruff",
     "pyright",
     "django-stubs",
+    "django-test-migrations",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
On an empty db we should still be able to run part of the migration plan e.g. only do the first of the first app:

manage.py contenttypes 0001_initial

This should not fail hard just because our Version table doesn't exist yet.